### PR TITLE
fix - jenkinsfile build 위치 변경

### DIFF
--- a/server/Jenkinsfile
+++ b/server/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh './gradlew build'
+                sh './server/gradlew build'
             }
         }
         stage('Dockerize') {


### PR DESCRIPTION
FROM >  sh './gradlew build'
TO >  sh './server/gradlew build'